### PR TITLE
Add OIDC / Single Sign-On authentication support

### DIFF
--- a/Kuna/App/AppState.swift
+++ b/Kuna/App/AppState.swift
@@ -1,10 +1,12 @@
 // App/AppState.swift
 import SwiftUI
 import Foundation
+import AuthenticationServices
 
 enum AuthenticationMethod: String, CaseIterable {
     case usernamePassword = "Username & Password"
     case personalToken = "Personal API Token"
+    case oidc = "Single Sign-On (OIDC)"
 
     var description: String {
         return self.rawValue
@@ -14,6 +16,7 @@ enum AuthenticationMethod: String, CaseIterable {
         switch self {
         case .usernamePassword: return "person.circle"
         case .personalToken: return "key"
+        case .oidc: return "person.badge.key"
         }
     }
 }
@@ -43,8 +46,8 @@ final class AppState: ObservableObject {
                 let authMethod = Keychain.readAuthMethod()
                 self.authenticationMethod = authMethod
                 
-                // Only set refresh handlers for username/password auth (JWT tokens)
-                if authMethod == .usernamePassword {
+                // JWT-based methods (username/password and OIDC) get token refresh support
+                if authMethod == .usernamePassword || authMethod == .oidc {
                     self.api = VikunjaAPI(
                         config: .init(baseURL: apiURL),
                         tokenProvider: {
@@ -241,6 +244,40 @@ final class AppState: ObservableObject {
         tokenExpirationDate = nil
     }
 
+    func loginWithOIDC(serverURL: String, provider: OIDCProvider) async throws {
+        let apiURL = try Self.buildAPIURL(from: serverURL)
+
+        // Build the full auth URL — Vikunja returns absolute URLs in auth_url
+        guard let authURL = URL(string: provider.authUrl) else {
+            throw APIError.badURL
+        }
+
+        let manager = OIDCAuthManager()
+        let token = try await manager.authenticate(authURL: authURL, callbackScheme: "kuna")
+
+        let expirationDate = try? JWTDecoder.getExpirationDate(from: token)
+
+        try Keychain.saveToken(token)
+        try Keychain.saveServerURL(serverURL)
+        try Keychain.saveAuthMethod(.oidc)
+        try? Keychain.saveOIDCProvider(provider.key)
+
+        self.api = VikunjaAPI(
+            config: .init(baseURL: apiURL),
+            tokenProvider: { Keychain.readToken() },
+            tokenRefreshHandler: { [weak self] newToken in
+                try await self?.refreshToken(newToken: newToken)
+            },
+            tokenRefreshFailureHandler: { [weak self] in
+                self?.handleTokenRefreshFailure()
+            }
+        )
+
+        isAuthenticated = true
+        authenticationMethod = .oidc
+        tokenExpirationDate = expirationDate
+    }
+
     func logout() {
         Keychain.clearAll()
         // Reset app preferences on sign out
@@ -269,9 +306,9 @@ final class AppState: ObservableObject {
         return timeInterval > 0 ? timeInterval : nil
     }
 
-    /// User management features are only available for username/password authentication
+    /// User management features are available for JWT-based authentication (username/password and OIDC)
     var canManageUsers: Bool {
-        return authenticationMethod == .usernamePassword
+        return authenticationMethod == .usernamePassword || authenticationMethod == .oidc
     }
 
     // MARK: - Token Refresh

--- a/Kuna/App/AppState.swift
+++ b/Kuna/App/AppState.swift
@@ -245,8 +245,6 @@ final class AppState: ObservableObject {
     }
 
     func loginWithOIDC(serverURL: String, provider: OIDCProvider) async throws {
-        let apiURL = try Self.buildAPIURL(from: serverURL)
-
         // Use custom redirect URI if configured, otherwise fall back to kuna:// custom scheme
         let customURI = AppSettings.shared.oidcRedirectURI.trimmingCharacters(in: .whitespacesAndNewlines)
         let redirectURI = customURI.isEmpty ? defaultOIDCRedirectURI : customURI
@@ -268,8 +266,8 @@ final class AppState: ObservableObject {
         try Keychain.saveToken(token)
         try Keychain.saveServerURL(serverURL)
         try Keychain.saveAuthMethod(.oidc)
-        try? Keychain.saveOIDCProvider(provider.key)
 
+        let apiURL = try Self.buildAPIURL(from: serverURL)
         self.api = VikunjaAPI(
             config: .init(baseURL: apiURL),
             tokenProvider: { Keychain.readToken() },

--- a/Kuna/App/AppState.swift
+++ b/Kuna/App/AppState.swift
@@ -247,13 +247,16 @@ final class AppState: ObservableObject {
     func loginWithOIDC(serverURL: String, provider: OIDCProvider) async throws {
         let apiURL = try Self.buildAPIURL(from: serverURL)
 
-        // Build the full auth URL — Vikunja returns absolute URLs in auth_url
-        guard let authURL = URL(string: provider.authUrl) else {
-            throw APIError.badURL
-        }
-
+        // Step 1: open browser, get authorization code from IdP
         let manager = OIDCAuthManager()
-        let token = try await manager.authenticate(authURL: authURL, callbackScheme: "kuna")
+        let code = try await manager.getAuthorizationCode(for: provider)
+
+        // Step 2: exchange code with Vikunja to get a Vikunja JWT
+        let token = try await VikunjaAPI.exchangeOIDCCode(
+            serverURL: serverURL,
+            providerKey: provider.key,
+            code: code
+        )
 
         let expirationDate = try? JWTDecoder.getExpirationDate(from: token)
 

--- a/Kuna/App/AppState.swift
+++ b/Kuna/App/AppState.swift
@@ -247,15 +247,20 @@ final class AppState: ObservableObject {
     func loginWithOIDC(serverURL: String, provider: OIDCProvider) async throws {
         let apiURL = try Self.buildAPIURL(from: serverURL)
 
+        // Use custom redirect URI if configured, otherwise fall back to kuna:// custom scheme
+        let customURI = AppSettings.shared.oidcRedirectURI.trimmingCharacters(in: .whitespacesAndNewlines)
+        let redirectURI = customURI.isEmpty ? defaultOIDCRedirectURI : customURI
+
         // Step 1: open browser, get authorization code from IdP
         let manager = OIDCAuthManager()
-        let code = try await manager.getAuthorizationCode(for: provider)
+        let code = try await manager.getAuthorizationCode(for: provider, redirectURI: redirectURI)
 
         // Step 2: exchange code with Vikunja to get a Vikunja JWT
         let token = try await VikunjaAPI.exchangeOIDCCode(
             serverURL: serverURL,
             providerKey: provider.key,
-            code: code
+            code: code,
+            redirectURI: redirectURI
         )
 
         let expirationDate = try? JWTDecoder.getExpirationDate(from: token)

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -96,6 +96,40 @@ struct LoginView: View {
                             ForEach(LoginMode.allCases) { Text($0.rawValue).tag($0) }
                         }
                         .pickerStyle(.segmented)
+
+                        if isFetchingProviders {
+                            HStack(spacing: 8) {
+                                ProgressView().scaleEffect(0.8)
+                                Text(String(localized: "auth.oidc.fetchingProviders",
+                                            comment: "Loading OIDC providers"))
+                                    .font(.footnote)
+                                    .foregroundColor(.secondary)
+                            }
+                        } else {
+                            ForEach(oidcProviders) { provider in
+                                Button {
+                                    loginWithOIDC(provider: provider)
+                                } label: {
+                                    HStack {
+                                        if isLoggingIn {
+                                            ProgressView().scaleEffect(0.8).padding(.trailing, 4)
+                                        } else {
+                                            Image(systemName: "person.badge.key")
+                                        }
+                                        Text(
+                                            String(
+                                                format: String(localized: "auth.oidc.signInWith",
+                                                               comment: "Sign in with provider name"),
+                                                provider.name
+                                            )
+                                        )
+                                    }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .disabled(!isServerValid || isLoggingIn)
+                            }
+                        }
                     } footer: {
                         VStack(alignment: .leading, spacing: 8) {
                             HStack(alignment: .top, spacing: 6) {
@@ -195,48 +229,6 @@ struct LoginView: View {
                         }
                     }
 
-                    if !oidcProviders.isEmpty {
-                        Section(String(localized: "auth.oidc.section", comment: "Single sign-on section")) {
-                            ForEach(oidcProviders) { provider in
-                                Button {
-                                    loginWithOIDC(provider: provider)
-                                } label: {
-                                    HStack {
-                                        if isLoggingIn {
-                                            ProgressView()
-                                                .scaleEffect(0.8)
-                                                .padding(.trailing, 4)
-                                        } else {
-                                            Image(systemName: "person.badge.key")
-                                        }
-                                        Text(
-                                            String(
-                                                format: String(localized: "auth.oidc.signInWith",
-                                                               comment: "Sign in with provider name"),
-                                                provider.name
-                                            )
-                                        )
-                                    }
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .disabled(!isServerValid || isLoggingIn)
-                            }
-                        }
-                    } else if isFetchingProviders {
-                        Section {
-                            HStack(spacing: 8) {
-                                ProgressView()
-                                    .scaleEffect(0.8)
-                                Text(String(localized: "auth.oidc.fetchingProviders",
-                                            comment: "Loading OIDC providers"))
-                                    .font(.footnote)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                        .listRowBackground(Color.clear)
-                    }
-
                     if let e = error, !e.isEmpty {
                         Section { Text(e).foregroundColor(.red).font(.callout) }
                     }
@@ -245,9 +237,6 @@ struct LoginView: View {
                 .scrollContentBackground(.hidden) // let the ZStack background show
                 .onChange(of: serverURL) { _, newValue in
                     fetchOIDCProviders(for: newValue)
-                }
-                .onAppear {
-                    fetchOIDCProviders(for: serverURL)
                 }
             }
             // Hide the nav title to avoid duplicate "Kuna" text

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -123,17 +123,15 @@ struct LoginView: View {
                     }
 
                     if mode == .sso {
-                        Section(String(localized: "auth.oidc.section", comment: "Single sign-on section")) {
+                        Section("Single Sign-On") {
                             if isFetchingProviders {
                                 HStack(spacing: 8) {
                                     ProgressView().scaleEffect(0.8)
-                                    Text(String(localized: "auth.oidc.fetchingProviders",
-                                                comment: "Loading OIDC providers"))
+                                    Text("Loading sign-on options…")
                                         .foregroundColor(.secondary)
                                 }
                             } else if oidcProviders.isEmpty {
-                                Text(String(localized: "auth.oidc.noProviders",
-                                            comment: "No SSO providers found for this server"))
+                                Text("No sign-on providers found for this server.")
                                     .foregroundColor(.secondary)
                                     .font(.callout)
                             } else {
@@ -147,13 +145,7 @@ struct LoginView: View {
                                             } else {
                                                 Image(systemName: "person.badge.key")
                                             }
-                                            Text(
-                                                String(
-                                                    format: String(localized: "auth.oidc.signInWith",
-                                                                   comment: "Sign in with provider name"),
-                                                    provider.name
-                                                )
-                                            )
+                                            Text("Sign in with \(provider.name)")
                                         }
                                     }
                                     .buttonStyle(.borderedProminent)

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -5,7 +5,7 @@ struct LoginView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     enum LoginMode: String, CaseIterable, Identifiable {
-        case password = "Password", token = "API Token"
+        case password = "Password", token = "API Token", sso = "SSO"
         var id: String { rawValue }
     }
 
@@ -73,7 +73,10 @@ struct LoginView: View {
                                     .textContentType(.URL)
                                     .focused($focused, equals: .server)
                                     .submitLabel(.next)
-                                    .onSubmit { focused = mode == .password ? .username : .token }
+                                    .onSubmit {
+                                        if mode == .password { focused = .username }
+                                        else if mode == .token { focused = .token }
+                                    }
                             }
 
                             Button {
@@ -96,40 +99,6 @@ struct LoginView: View {
                             ForEach(LoginMode.allCases) { Text($0.rawValue).tag($0) }
                         }
                         .pickerStyle(.segmented)
-
-                        if isFetchingProviders {
-                            HStack(spacing: 8) {
-                                ProgressView().scaleEffect(0.8)
-                                Text(String(localized: "auth.oidc.fetchingProviders",
-                                            comment: "Loading OIDC providers"))
-                                    .font(.footnote)
-                                    .foregroundColor(.secondary)
-                            }
-                        } else {
-                            ForEach(oidcProviders) { provider in
-                                Button {
-                                    loginWithOIDC(provider: provider)
-                                } label: {
-                                    HStack {
-                                        if isLoggingIn {
-                                            ProgressView().scaleEffect(0.8).padding(.trailing, 4)
-                                        } else {
-                                            Image(systemName: "person.badge.key")
-                                        }
-                                        Text(
-                                            String(
-                                                format: String(localized: "auth.oidc.signInWith",
-                                                               comment: "Sign in with provider name"),
-                                                provider.name
-                                            )
-                                        )
-                                    }
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .disabled(!isServerValid || isLoggingIn)
-                            }
-                        }
                     } footer: {
                         VStack(alignment: .leading, spacing: 8) {
                             HStack(alignment: .top, spacing: 6) {
@@ -153,7 +122,47 @@ struct LoginView: View {
                         .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    if mode == .password {
+                    if mode == .sso {
+                        Section(String(localized: "auth.oidc.section", comment: "Single sign-on section")) {
+                            if isFetchingProviders {
+                                HStack(spacing: 8) {
+                                    ProgressView().scaleEffect(0.8)
+                                    Text(String(localized: "auth.oidc.fetchingProviders",
+                                                comment: "Loading OIDC providers"))
+                                        .foregroundColor(.secondary)
+                                }
+                            } else if oidcProviders.isEmpty {
+                                Text(String(localized: "auth.oidc.noProviders",
+                                            comment: "No SSO providers found for this server"))
+                                    .foregroundColor(.secondary)
+                                    .font(.callout)
+                            } else {
+                                ForEach(oidcProviders) { provider in
+                                    Button {
+                                        loginWithOIDC(provider: provider)
+                                    } label: {
+                                        HStack {
+                                            if isLoggingIn {
+                                                ProgressView().scaleEffect(0.8).padding(.trailing, 4)
+                                            } else {
+                                                Image(systemName: "person.badge.key")
+                                            }
+                                            Text(
+                                                String(
+                                                    format: String(localized: "auth.oidc.signInWith",
+                                                                   comment: "Sign in with provider name"),
+                                                    provider.name
+                                                )
+                                            )
+                                        }
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .disabled(!isServerValid || isLoggingIn)
+                                }
+                            }
+                        }
+                    } else if mode == .password {
                         Section(String(localized: "auth.usernamePassword", comment: "Username & Password")) {
                             TextField(String(localized: "auth.username", comment: "Username"), text: $username)
                                 .textInputAutocapitalization(.never)

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -145,7 +145,7 @@ struct LoginView: View {
                                             } else {
                                                 Image(systemName: "person.badge.key")
                                             }
-                                            Text("Sign in with \(provider.name)")
+                                            Text("Sign in with \(provider.name.capitalized)")
                                         }
                                     }
                                     .buttonStyle(.borderedProminent)

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -246,6 +246,9 @@ struct LoginView: View {
                 .onChange(of: serverURL) { _, newValue in
                     fetchOIDCProviders(for: newValue)
                 }
+                .onAppear {
+                    fetchOIDCProviders(for: serverURL)
+                }
             }
             // Hide the nav title to avoid duplicate "Kuna" text
             .toolbar { ToolbarItem(placement: .principal) { EmptyView() } }
@@ -330,6 +333,7 @@ struct LoginView: View {
             } catch {
                 guard !Task.isCancelled else { return }
                 oidcProviders = []
+                Log.app.error("OIDC provider fetch failed: \(String(describing: error), privacy: .public)")
             }
             isFetchingProviders = false
         }

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct LoginView: View {
     @EnvironmentObject var app: AppState
     @Environment(\.colorScheme) private var colorScheme
+    @StateObject private var settings = AppSettings.shared
 
     enum LoginMode: String, CaseIterable, Identifiable {
         case password = "Password", token = "API Token", sso = "SSO"
@@ -153,6 +154,22 @@ struct LoginView: View {
                                     .disabled(!isServerValid || isLoggingIn)
                                 }
                             }
+                        }
+
+                        Section {
+                            TextField("https://redirect.example.com/auth/callback",
+                                      text: $settings.oidcRedirectURI)
+                                .font(.caption)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .keyboardType(.URL)
+                                .textContentType(.URL)
+                        } header: {
+                            Text("Redirect URI")
+                        } footer: {
+                            Text("Leave blank to use kuna:// (works with most providers). Set to your redirect service URL if your provider requires HTTPS.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
                         }
                     } else if mode == .password {
                         Section(String(localized: "auth.usernamePassword", comment: "Username & Password")) {

--- a/Kuna/Features/Auth/LoginView.swift
+++ b/Kuna/Features/Auth/LoginView.swift
@@ -19,6 +19,9 @@ struct LoginView: View {
     @State private var showingTOTP = false
     @State private var totpCode = ""
     @State private var isLoggingIn = false
+    @State private var oidcProviders: [OIDCProvider] = []
+    @State private var isFetchingProviders = false
+    @State private var serverInfoTask: Task<Void, Never>?
 
     @FocusState private var focused: Field?
     enum Field { case server, username, password, token, totp }
@@ -192,12 +195,57 @@ struct LoginView: View {
                         }
                     }
 
+                    if !oidcProviders.isEmpty {
+                        Section(String(localized: "auth.oidc.section", comment: "Single sign-on section")) {
+                            ForEach(oidcProviders) { provider in
+                                Button {
+                                    loginWithOIDC(provider: provider)
+                                } label: {
+                                    HStack {
+                                        if isLoggingIn {
+                                            ProgressView()
+                                                .scaleEffect(0.8)
+                                                .padding(.trailing, 4)
+                                        } else {
+                                            Image(systemName: "person.badge.key")
+                                        }
+                                        Text(
+                                            String(
+                                                format: String(localized: "auth.oidc.signInWith",
+                                                               comment: "Sign in with provider name"),
+                                                provider.name
+                                            )
+                                        )
+                                    }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .disabled(!isServerValid || isLoggingIn)
+                            }
+                        }
+                    } else if isFetchingProviders {
+                        Section {
+                            HStack(spacing: 8) {
+                                ProgressView()
+                                    .scaleEffect(0.8)
+                                Text(String(localized: "auth.oidc.fetchingProviders",
+                                            comment: "Loading OIDC providers"))
+                                    .font(.footnote)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                        .listRowBackground(Color.clear)
+                    }
+
                     if let e = error, !e.isEmpty {
                         Section { Text(e).foregroundColor(.red).font(.callout) }
                     }
                 }
                 .listStyle(.insetGrouped)
                 .scrollContentBackground(.hidden) // let the ZStack background show
+                .onChange(of: serverURL) { _, newValue in
+                    fetchOIDCProviders(for: newValue)
+                }
             }
             // Hide the nav title to avoid duplicate "Kuna" text
             .toolbar { ToolbarItem(placement: .principal) { EmptyView() } }
@@ -250,6 +298,40 @@ struct LoginView: View {
             try app.usePersonalToken(serverURL: serverURL, token: personalToken)
         } catch {
             self.error = error.localizedDescription
+        }
+    }
+
+    private func loginWithOIDC(provider: OIDCProvider) {
+        isLoggingIn = true
+        error = nil
+        Task {
+            do {
+                try await app.loginWithOIDC(serverURL: serverURL, provider: provider)
+                isLoggingIn = false
+            } catch let oidcError as OIDCError where oidcError == .cancelled {
+                isLoggingIn = false
+            } catch {
+                isLoggingIn = false
+                self.error = error.localizedDescription
+            }
+        }
+    }
+
+    private func fetchOIDCProviders(for url: String) {
+        serverInfoTask?.cancel()
+        oidcProviders = []
+        guard isServerValid else { return }
+        isFetchingProviders = true
+        serverInfoTask = Task {
+            do {
+                let info = try await VikunjaAPI.fetchServerInfo(serverURL: url)
+                guard !Task.isCancelled else { return }
+                oidcProviders = info.auth?.openidConnect?.providers ?? []
+            } catch {
+                guard !Task.isCancelled else { return }
+                oidcProviders = []
+            }
+            isFetchingProviders = false
         }
     }
 }

--- a/Kuna/Features/Settings/SettingsView.swift
+++ b/Kuna/Features/Settings/SettingsView.swift
@@ -347,7 +347,23 @@ struct SettingsView: View {
                         StatusIcon(systemName: status.0, color: status.1)
                     }
             }
-        } header: { 
+            HStack(spacing: 12) {
+                LeadingIcon(systemName: "arrow.triangle.2.circlepath", color: .purple)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("SSO Redirect URI").font(.body)
+                    Text("Leave blank to use kuna:// (default). Set to your redirect service URL if your provider requires HTTPS.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            TextField("https://redirect.example.com/auth/callback",
+                      text: $settings.oidcRedirectURI)
+                .font(.caption)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .textContentType(.URL)
+        } header: {
             Text(String(localized: "settings.connection.header", comment: "Connection settings header"))
         }
     }

--- a/Kuna/Features/Settings/SettingsView.swift
+++ b/Kuna/Features/Settings/SettingsView.swift
@@ -347,22 +347,6 @@ struct SettingsView: View {
                         StatusIcon(systemName: status.0, color: status.1)
                     }
             }
-            HStack(spacing: 12) {
-                LeadingIcon(systemName: "arrow.triangle.2.circlepath", color: .purple)
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("SSO Redirect URI").font(.body)
-                    Text("Leave blank to use kuna:// (default). Set to your redirect service URL if your provider requires HTTPS.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-            }
-            TextField("https://redirect.example.com/auth/callback",
-                      text: $settings.oidcRedirectURI)
-                .font(.caption)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .keyboardType(.URL)
-                .textContentType(.URL)
         } header: {
             Text(String(localized: "settings.connection.header", comment: "Connection settings header"))
         }

--- a/Kuna/Info.plist
+++ b/Kuna/Info.plist
@@ -105,5 +105,16 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kuna</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>tech.systemsmystery.kuna</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Kuna/Models/VikunjaServerInfo.swift
+++ b/Kuna/Models/VikunjaServerInfo.swift
@@ -24,7 +24,10 @@ struct VikunjaServerInfo: Decodable {
 struct OIDCProvider: Decodable, Identifiable {
     let name: String
     let key: String
+    /// Authorization endpoint URL (e.g. https://sso.example.com/oauth/authorize)
     let authUrl: String
+    let clientId: String
+    let scope: String
 
     var id: String { key }
 
@@ -32,5 +35,7 @@ struct OIDCProvider: Decodable, Identifiable {
         case name
         case key
         case authUrl = "auth_url"
+        case clientId = "client_id"
+        case scope
     }
 }

--- a/Kuna/Models/VikunjaServerInfo.swift
+++ b/Kuna/Models/VikunjaServerInfo.swift
@@ -1,0 +1,36 @@
+// Models/VikunjaServerInfo.swift
+import Foundation
+
+struct VikunjaServerInfo: Decodable {
+    let version: String?
+    let auth: AuthInfo?
+
+    struct AuthInfo: Decodable {
+        let localEnabled: Bool?
+        let openidConnect: OpenIDConnectInfo?
+
+        enum CodingKeys: String, CodingKey {
+            case localEnabled = "local_enabled"
+            case openidConnect = "openid_connect"
+        }
+    }
+
+    struct OpenIDConnectInfo: Decodable {
+        let enabled: Bool
+        let providers: [OIDCProvider]?
+    }
+}
+
+struct OIDCProvider: Decodable, Identifiable {
+    let name: String
+    let key: String
+    let authUrl: String
+
+    var id: String { key }
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case key
+        case authUrl = "auth_url"
+    }
+}

--- a/Kuna/Services/AppSettings.swift
+++ b/Kuna/Services/AppSettings.swift
@@ -213,6 +213,11 @@ final class AppSettings: ObservableObject {
         }
     }
 
+    // MARK: - OIDC
+    @Published var oidcRedirectURI: String {
+        didSet { UserDefaults.standard.set(oidcRedirectURI, forKey: "oidcRedirectURI") }
+    }
+
     // MARK: - Analytics Preference
     @Published var analyticsEnabled: Bool {
         didSet {
@@ -257,6 +262,8 @@ final class AppSettings: ObservableObject {
         self.showSyncStatus = UserDefaults.standard.object(forKey: "showSyncStatus") as? Bool ?? true
 
         self.celebrateCompletionConfetti = UserDefaults.standard.object(forKey: "celebrateCompletionConfetti") as? Bool ?? false
+
+        self.oidcRedirectURI = UserDefaults.standard.string(forKey: "oidcRedirectURI") ?? ""
 
         self.analyticsEnabled = UserDefaults.standard.object(forKey: "analyticsEnabled") as? Bool ?? false
         self.analyticsConsentDecision = UserDefaults.standard.string(forKey: "analyticsConsentDecision")
@@ -317,7 +324,8 @@ final class AppSettings: ObservableObject {
             "showEndDate",
             "showSyncStatus",
             "analyticsEnabled",
-            "analyticsConsentDecision"
+            "analyticsConsentDecision",
+            "oidcRedirectURI"
         ]
         keys.forEach { defaults.removeObject(forKey: $0) }
 

--- a/Kuna/Services/Keychain.swift
+++ b/Kuna/Services/Keychain.swift
@@ -161,24 +161,11 @@ enum Keychain {
         delete(account: "vikunja-auth-method")
     }
 
-    // OIDC provider storage
-    static func saveOIDCProvider(_ key: String) throws {
-        try save(token: key, account: "vikunja-oidc-provider")
-    }
-
-    static func readOIDCProvider() -> String? {
-        return read(account: "vikunja-oidc-provider")
-    }
-
-    static func deleteOIDCProvider() {
-        delete(account: "vikunja-oidc-provider")
-    }
-
     // Clear all
     static func clearAll() {
         deleteToken()
         deleteServerURL()
         deleteAuthMethod()
-        deleteOIDCProvider()
+        delete(account: "vikunja-oidc-provider")
     }
 }

--- a/Kuna/Services/Keychain.swift
+++ b/Kuna/Services/Keychain.swift
@@ -161,10 +161,24 @@ enum Keychain {
         delete(account: "vikunja-auth-method")
     }
 
+    // OIDC provider storage
+    static func saveOIDCProvider(_ key: String) throws {
+        try save(token: key, account: "vikunja-oidc-provider")
+    }
+
+    static func readOIDCProvider() -> String? {
+        return read(account: "vikunja-oidc-provider")
+    }
+
+    static func deleteOIDCProvider() {
+        delete(account: "vikunja-oidc-provider")
+    }
+
     // Clear all
     static func clearAll() {
         deleteToken()
         deleteServerURL()
         deleteAuthMethod()
+        deleteOIDCProvider()
     }
 }

--- a/Kuna/Services/OIDCAuthManager.swift
+++ b/Kuna/Services/OIDCAuthManager.swift
@@ -1,0 +1,82 @@
+// Services/OIDCAuthManager.swift
+import AuthenticationServices
+import Foundation
+
+enum OIDCError: Error, LocalizedError, Equatable {
+    case cancelled
+    case missingToken
+    case invalidCallbackURL
+
+    var errorDescription: String? {
+        switch self {
+        case .cancelled:          return String(localized: "auth.oidc.error.cancelled")
+        case .missingToken:       return String(localized: "auth.oidc.error.missingToken")
+        case .invalidCallbackURL: return String(localized: "auth.oidc.error.invalidCallback")
+        }
+    }
+}
+
+@MainActor
+final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextProviding {
+
+    func authenticate(authURL: URL, callbackScheme: String) async throws -> String {
+        return try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: callbackScheme
+            ) { callbackURL, error in
+                if let error {
+                    let nsError = error as NSError
+                    if nsError.code == ASWebAuthenticationSessionError.canceledLogin.rawValue {
+                        continuation.resume(throwing: OIDCError.cancelled)
+                    } else {
+                        continuation.resume(throwing: error)
+                    }
+                    return
+                }
+                guard let callbackURL else {
+                    continuation.resume(throwing: OIDCError.invalidCallbackURL)
+                    return
+                }
+                guard let token = Self.extractToken(from: callbackURL) else {
+                    continuation.resume(throwing: OIDCError.missingToken)
+                    return
+                }
+                continuation.resume(returning: token)
+            }
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            session.start()
+        }
+    }
+
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        // Return the key window as the presentation anchor
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first as? UIWindowScene
+        return windowScene?.windows.first { $0.isKeyWindow } ?? UIWindow()
+    }
+
+    // Extract token from callback URL.
+    // Vikunja may return the token in different places depending on version:
+    //   kuna://auth/callback?token=...
+    //   kuna://auth/callback#token=...  (fragment)
+    private static func extractToken(from url: URL) -> String? {
+        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            // Check query parameters first
+            if let token = components.queryItems?.first(where: { $0.name == "token" })?.value,
+               !token.isEmpty {
+                return token
+            }
+            // Check URL fragment (hash)
+            if let fragment = components.fragment {
+                let fragmentComponents = URLComponents(string: "?\(fragment)")
+                if let token = fragmentComponents?.queryItems?.first(where: { $0.name == "token" })?.value,
+                   !token.isEmpty {
+                    return token
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Kuna/Services/OIDCAuthManager.swift
+++ b/Kuna/Services/OIDCAuthManager.swift
@@ -4,26 +4,75 @@ import Foundation
 
 enum OIDCError: Error, LocalizedError, Equatable {
     case cancelled
-    case missingToken
+    case missingCode
+    case stateMismatch
     case invalidCallbackURL
+    case badAuthURL
 
     var errorDescription: String? {
         switch self {
-        case .cancelled:          return String(localized: "auth.oidc.error.cancelled")
-        case .missingToken:       return String(localized: "auth.oidc.error.missingToken")
-        case .invalidCallbackURL: return String(localized: "auth.oidc.error.invalidCallback")
+        case .cancelled:           return String(localized: "auth.oidc.error.cancelled")
+        case .missingCode:         return String(localized: "auth.oidc.error.missingCode")
+        case .stateMismatch:       return String(localized: "auth.oidc.error.stateMismatch")
+        case .invalidCallbackURL:  return String(localized: "auth.oidc.error.invalidCallback")
+        case .badAuthURL:          return String(localized: "auth.oidc.error.badAuthURL")
         }
     }
 }
 
+private let redirectURI = "kuna://auth/callback"
+
 @MainActor
 final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextProviding {
 
-    func authenticate(authURL: URL, callbackScheme: String) async throws -> String {
+    /// Opens a browser for the given OIDC provider, captures the authorization code,
+    /// then returns it. The caller is responsible for exchanging the code with Vikunja.
+    func getAuthorizationCode(for provider: OIDCProvider) async throws -> String {
+        guard var components = URLComponents(string: provider.authUrl) else {
+            throw OIDCError.badAuthURL
+        }
+
+        // Generate a random state value to protect against CSRF
+        let state = UUID().uuidString
+
+        components.queryItems = (components.queryItems ?? []) + [
+            URLQueryItem(name: "client_id",     value: provider.clientId),
+            URLQueryItem(name: "redirect_uri",  value: redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope",         value: provider.scope),
+            URLQueryItem(name: "state",         value: state),
+        ]
+
+        guard let authURL = components.url else {
+            throw OIDCError.badAuthURL
+        }
+
+        let callbackURL = try await openBrowser(to: authURL)
+
+        guard let returnedComponents = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false) else {
+            throw OIDCError.invalidCallbackURL
+        }
+
+        let items = returnedComponents.queryItems ?? []
+
+        // Verify state to prevent CSRF
+        let returnedState = items.first(where: { $0.name == "state" })?.value
+        guard returnedState == state else {
+            throw OIDCError.stateMismatch
+        }
+
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw OIDCError.missingCode
+        }
+
+        return code
+    }
+
+    private func openBrowser(to url: URL) async throws -> URL {
         return try await withCheckedThrowingContinuation { continuation in
             let session = ASWebAuthenticationSession(
-                url: authURL,
-                callbackURLScheme: callbackScheme
+                url: url,
+                callbackURLScheme: "kuna"
             ) { callbackURL, error in
                 if let error {
                     let nsError = error as NSError
@@ -38,11 +87,7 @@ final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextPro
                     continuation.resume(throwing: OIDCError.invalidCallbackURL)
                     return
                 }
-                guard let token = Self.extractToken(from: callbackURL) else {
-                    continuation.resume(throwing: OIDCError.missingToken)
-                    return
-                }
-                continuation.resume(returning: token)
+                continuation.resume(returning: callbackURL)
             }
             session.presentationContextProvider = self
             session.prefersEphemeralWebBrowserSession = false
@@ -51,32 +96,8 @@ final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextPro
     }
 
     nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        // Return the key window as the presentation anchor
         let scenes = UIApplication.shared.connectedScenes
         let windowScene = scenes.first as? UIWindowScene
         return windowScene?.windows.first { $0.isKeyWindow } ?? UIWindow()
-    }
-
-    // Extract token from callback URL.
-    // Vikunja may return the token in different places depending on version:
-    //   kuna://auth/callback?token=...
-    //   kuna://auth/callback#token=...  (fragment)
-    private static func extractToken(from url: URL) -> String? {
-        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-            // Check query parameters first
-            if let token = components.queryItems?.first(where: { $0.name == "token" })?.value,
-               !token.isEmpty {
-                return token
-            }
-            // Check URL fragment (hash)
-            if let fragment = components.fragment {
-                let fragmentComponents = URLComponents(string: "?\(fragment)")
-                if let token = fragmentComponents?.queryItems?.first(where: { $0.name == "token" })?.value,
-                   !token.isEmpty {
-                    return token
-                }
-            }
-        }
-        return nil
     }
 }

--- a/Kuna/Services/OIDCAuthManager.swift
+++ b/Kuna/Services/OIDCAuthManager.swift
@@ -20,14 +20,14 @@ enum OIDCError: Error, LocalizedError, Equatable {
     }
 }
 
-private let redirectURI = "kuna://auth/callback"
+let defaultOIDCRedirectURI = "kuna://auth/callback"
 
 @MainActor
 final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextProviding {
 
     /// Opens a browser for the given OIDC provider, captures the authorization code,
     /// then returns it. The caller is responsible for exchanging the code with Vikunja.
-    func getAuthorizationCode(for provider: OIDCProvider) async throws -> String {
+    func getAuthorizationCode(for provider: OIDCProvider, redirectURI: String) async throws -> String {
         guard var components = URLComponents(string: provider.authUrl) else {
             throw OIDCError.badAuthURL
         }
@@ -47,7 +47,8 @@ final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextPro
             throw OIDCError.badAuthURL
         }
 
-        let callbackURL = try await openBrowser(to: authURL)
+        let callbackScheme = URL(string: redirectURI)?.scheme ?? "kuna"
+        let callbackURL = try await openBrowser(to: authURL, callbackScheme: callbackScheme)
 
         guard let returnedComponents = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false) else {
             throw OIDCError.invalidCallbackURL
@@ -68,11 +69,11 @@ final class OIDCAuthManager: NSObject, ASWebAuthenticationPresentationContextPro
         return code
     }
 
-    private func openBrowser(to url: URL) async throws -> URL {
+    private func openBrowser(to url: URL, callbackScheme: String) async throws -> URL {
         return try await withCheckedThrowingContinuation { continuation in
             let session = ASWebAuthenticationSession(
                 url: url,
-                callbackURLScheme: "kuna"
+                callbackURLScheme: callbackScheme
             ) { callbackURL, error in
                 if let error {
                     let nsError = error as NSError

--- a/Kuna/Services/OIDCAuthManager.swift
+++ b/Kuna/Services/OIDCAuthManager.swift
@@ -11,11 +11,11 @@ enum OIDCError: Error, LocalizedError, Equatable {
 
     var errorDescription: String? {
         switch self {
-        case .cancelled:           return String(localized: "auth.oidc.error.cancelled")
-        case .missingCode:         return String(localized: "auth.oidc.error.missingCode")
-        case .stateMismatch:       return String(localized: "auth.oidc.error.stateMismatch")
-        case .invalidCallbackURL:  return String(localized: "auth.oidc.error.invalidCallback")
-        case .badAuthURL:          return String(localized: "auth.oidc.error.badAuthURL")
+        case .cancelled:           return "Sign-in was cancelled."
+        case .missingCode:         return "No authorisation code was returned by the provider."
+        case .stateMismatch:       return "The sign-in response could not be verified. Please try again."
+        case .invalidCallbackURL:  return "The sign-in callback URL was invalid."
+        case .badAuthURL:          return "The provider's authorisation URL is invalid."
         }
     }
 }

--- a/Kuna/Services/VikunjaAPI.swift
+++ b/Kuna/Services/VikunjaAPI.swift
@@ -1385,7 +1385,9 @@ extension VikunjaAPI {
     /// Fetches server info including available OIDC providers.
     /// Uses a plain URLSession so no VikunjaAPI instance is needed.
     static func fetchServerInfo(serverURL: String) async throws -> VikunjaServerInfo {
-        let apiURL = try AppState.buildAPIURL(from: serverURL)
+        let clean = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let withScheme = clean.hasPrefix("http://") || clean.hasPrefix("https://") ? clean : "https://\(clean)"
+        guard let apiURL = URL(string: "\(withScheme)/api/v1") else { throw APIError.badURL }
         let infoURL = apiURL.appendingPathComponent("info")
         var req = URLRequest(url: infoURL)
         req.httpMethod = "GET"
@@ -1402,7 +1404,9 @@ extension VikunjaAPI {
     /// Exchanges an OIDC authorization code for a Vikunja JWT.
     /// Vikunja does the OAuth token exchange server-side and returns its own JWT.
     static func exchangeOIDCCode(serverURL: String, providerKey: String, code: String) async throws -> String {
-        let apiURL = try AppState.buildAPIURL(from: serverURL)
+        let clean = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let withScheme = clean.hasPrefix("http://") || clean.hasPrefix("https://") ? clean : "https://\(clean)"
+        guard let apiURL = URL(string: "\(withScheme)/api/v1") else { throw APIError.badURL }
         let callbackURL = apiURL
             .appendingPathComponent("auth")
             .appendingPathComponent("openid")

--- a/Kuna/Services/VikunjaAPI.swift
+++ b/Kuna/Services/VikunjaAPI.swift
@@ -1382,14 +1382,18 @@ extension VikunjaAPI {
 
     // MARK: - Server Info (no auth required)
 
+    private static func unauthenticatedAPIURL(from serverURL: String) throws -> URL {
+        let clean = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let withScheme = clean.hasPrefix("http://") || clean.hasPrefix("https://") ? clean : "https://\(clean)"
+        guard let url = URL(string: "\(withScheme)/api/v1") else { throw APIError.badURL }
+        return url
+    }
+
     /// Fetches server info including available OIDC providers.
     /// Uses a plain URLSession so no VikunjaAPI instance is needed.
     static func fetchServerInfo(serverURL: String) async throws -> VikunjaServerInfo {
-        let clean = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let withScheme = clean.hasPrefix("http://") || clean.hasPrefix("https://") ? clean : "https://\(clean)"
-        guard let apiURL = URL(string: "\(withScheme)/api/v1") else { throw APIError.badURL }
-        let infoURL = apiURL.appendingPathComponent("info")
-        var req = URLRequest(url: infoURL)
+        let apiURL = try unauthenticatedAPIURL(from: serverURL)
+        var req = URLRequest(url: apiURL.appendingPathComponent("info"))
         req.httpMethod = "GET"
         req.setValue("application/json", forHTTPHeaderField: "Accept")
         req.timeoutInterval = 10
@@ -1404,9 +1408,7 @@ extension VikunjaAPI {
     /// Exchanges an OIDC authorization code for a Vikunja JWT.
     /// Vikunja does the OAuth token exchange server-side and returns its own JWT.
     static func exchangeOIDCCode(serverURL: String, providerKey: String, code: String, redirectURI: String) async throws -> String {
-        let clean = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let withScheme = clean.hasPrefix("http://") || clean.hasPrefix("https://") ? clean : "https://\(clean)"
-        guard let apiURL = URL(string: "\(withScheme)/api/v1") else { throw APIError.badURL }
+        let apiURL = try unauthenticatedAPIURL(from: serverURL)
         let callbackURL = apiURL
             .appendingPathComponent("auth")
             .appendingPathComponent("openid")

--- a/Kuna/Services/VikunjaAPI.swift
+++ b/Kuna/Services/VikunjaAPI.swift
@@ -1398,4 +1398,39 @@ extension VikunjaAPI {
         }
         return try JSONDecoder.vikunja.decode(VikunjaServerInfo.self, from: data)
     }
+
+    /// Exchanges an OIDC authorization code for a Vikunja JWT.
+    /// Vikunja does the OAuth token exchange server-side and returns its own JWT.
+    static func exchangeOIDCCode(serverURL: String, providerKey: String, code: String) async throws -> String {
+        let apiURL = try AppState.buildAPIURL(from: serverURL)
+        let callbackURL = apiURL
+            .appendingPathComponent("auth")
+            .appendingPathComponent("openid")
+            .appendingPathComponent(providerKey)
+            .appendingPathComponent("callback")
+
+        struct CallbackBody: Encodable {
+            let code: String
+            let redirect_url: String
+        }
+        var req = URLRequest(url: callbackURL)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.httpBody = try JSONEncoder().encode(CallbackBody(code: code, redirect_url: "kuna://auth/callback"))
+        req.timeoutInterval = 15
+
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        guard let http = resp as? HTTPURLResponse else {
+            throw APIError.other("No HTTP response from OIDC callback")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            if let msg = try? JSONDecoder().decode([String: String].self, from: data)["message"] {
+                throw APIError.other(msg)
+            }
+            throw APIError.http(http.statusCode)
+        }
+        let auth = try JSONDecoder.vikunja.decode(AuthResponse.self, from: data)
+        return auth.token
+    }
 }

--- a/Kuna/Services/VikunjaAPI.swift
+++ b/Kuna/Services/VikunjaAPI.swift
@@ -1403,7 +1403,7 @@ extension VikunjaAPI {
 
     /// Exchanges an OIDC authorization code for a Vikunja JWT.
     /// Vikunja does the OAuth token exchange server-side and returns its own JWT.
-    static func exchangeOIDCCode(serverURL: String, providerKey: String, code: String) async throws -> String {
+    static func exchangeOIDCCode(serverURL: String, providerKey: String, code: String, redirectURI: String) async throws -> String {
         let clean = serverURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let withScheme = clean.hasPrefix("http://") || clean.hasPrefix("https://") ? clean : "https://\(clean)"
         guard let apiURL = URL(string: "\(withScheme)/api/v1") else { throw APIError.badURL }
@@ -1421,7 +1421,7 @@ extension VikunjaAPI {
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
         req.setValue("application/json", forHTTPHeaderField: "Accept")
-        req.httpBody = try JSONEncoder().encode(CallbackBody(code: code, redirect_url: "kuna://auth/callback"))
+        req.httpBody = try JSONEncoder().encode(CallbackBody(code: code, redirect_url: redirectURI))
         req.timeoutInterval = 15
 
         let (data, resp) = try await URLSession.shared.data(for: req)

--- a/Kuna/Services/VikunjaAPI.swift
+++ b/Kuna/Services/VikunjaAPI.swift
@@ -1379,4 +1379,23 @@ extension VikunjaAPI {
         }
         return results
     }
+
+    // MARK: - Server Info (no auth required)
+
+    /// Fetches server info including available OIDC providers.
+    /// Uses a plain URLSession so no VikunjaAPI instance is needed.
+    static func fetchServerInfo(serverURL: String) async throws -> VikunjaServerInfo {
+        let apiURL = try AppState.buildAPIURL(from: serverURL)
+        let infoURL = apiURL.appendingPathComponent("info")
+        var req = URLRequest(url: infoURL)
+        req.httpMethod = "GET"
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.timeoutInterval = 10
+
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw APIError.other("Server info request failed")
+        }
+        return try JSONDecoder.vikunja.decode(VikunjaServerInfo.self, from: data)
+    }
 }

--- a/KunaUnitTests/EnumTests.swift
+++ b/KunaUnitTests/EnumTests.swift
@@ -105,24 +105,28 @@ final class EnumTests: XCTestCase {
     func testAuthenticationMethodRawValues() {
         XCTAssertEqual(AuthenticationMethod.usernamePassword.rawValue, "Username & Password")
         XCTAssertEqual(AuthenticationMethod.personalToken.rawValue, "Personal API Token")
+        XCTAssertEqual(AuthenticationMethod.oidc.rawValue, "Single Sign-On (OIDC)")
     }
-    
+
     func testAuthenticationMethodDescriptions() {
         XCTAssertEqual(AuthenticationMethod.usernamePassword.description, "Username & Password")
         XCTAssertEqual(AuthenticationMethod.personalToken.description, "Personal API Token")
+        XCTAssertEqual(AuthenticationMethod.oidc.description, "Single Sign-On (OIDC)")
     }
-    
+
     func testAuthenticationMethodSystemImages() {
         XCTAssertEqual(AuthenticationMethod.usernamePassword.systemImage, "person.circle")
         XCTAssertEqual(AuthenticationMethod.personalToken.systemImage, "key")
+        XCTAssertEqual(AuthenticationMethod.oidc.systemImage, "person.badge.key")
     }
-    
+
     func testAuthenticationMethodAllCases() {
-        let expectedCount = 2
+        let expectedCount = 3
         XCTAssertEqual(AuthenticationMethod.allCases.count, expectedCount)
-        
+
         XCTAssertTrue(AuthenticationMethod.allCases.contains(.usernamePassword))
         XCTAssertTrue(AuthenticationMethod.allCases.contains(.personalToken))
+        XCTAssertTrue(AuthenticationMethod.allCases.contains(.oidc))
     }
     
     // MARK: - TaskRelationKind Tests


### PR DESCRIPTION
## Summary

This PR adds OIDC (Single Sign-On) as a third authentication method alongside the existing Username & Password and Personal API Token options.

- Fetches available OIDC providers from the Vikunja server's `/api/v1/info` endpoint automatically when a server URL is entered
- Presents providers as a dedicated **SSO** tab in the login screen's method picker
- Performs a standards-compliant OAuth 2.0 Authorization Code flow via `ASWebAuthenticationSession`, then exchanges the code with Vikunja's `/api/v1/auth/openid/{key}/callback` endpoint to receive a Vikunja JWT
- OIDC sessions reuse the existing JWT token refresh infrastructure — no special handling needed post-login
- Adds a configurable **Redirect URI** field on the SSO login screen (defaults to `kuna://` custom scheme; can be overridden to an HTTPS redirect service for providers that require it, e.g. Synology)
- Registers the `kuna://` URL scheme in `Info.plist`

## New files

| File | Purpose |
|---|---|
| `Kuna/Models/VikunjaServerInfo.swift` | Codable models for `/api/v1/info` response including `OIDCProvider` |
| `Kuna/Services/OIDCAuthManager.swift` | `ASWebAuthenticationSession` wrapper — builds auth URL, captures code, verifies state |

## Modified files

| File | Change |
|---|---|
| `Kuna/App/AppState.swift` | New `.oidc` case on `AuthenticationMethod`; `loginWithOIDC()` method; `canManageUsers` extended to include OIDC sessions |
| `Kuna/Services/VikunjaAPI.swift` | `fetchServerInfo()` and `exchangeOIDCCode()` static methods |
| `Kuna/Services/AppSettings.swift` | `oidcRedirectURI` setting persisted in UserDefaults |
| `Kuna/Features/Auth/LoginView.swift` | SSO tab with provider buttons, loading state, and redirect URI configuration field |
| `Kuna/Info.plist` | Registers `kuna://` URL scheme for OAuth callbacks |
| `KunaUnitTests/EnumTests.swift` | Updated for new `.oidc` case |

## Test plan

- [x] Enter a Vikunja server URL with OIDC configured → SSO tab shows provider button(s) automatically
- [x] Tap provider button → browser opens → authenticate → app logs in and lands on task list
- [x] Kill and relaunch → OIDC session restored from Keychain without re-login
- [x] Server with no OIDC providers → SSO tab shows "No sign-on providers found" message
- [x] All existing `KunaUnitTests` pass